### PR TITLE
refactor: Change to regmail rather than mail-relay

### DIFF
--- a/src/lib.js
+++ b/src/lib.js
@@ -269,7 +269,7 @@ export function formatEmail(projects, greeting){ // filtered list of projects, j
 export async function sendNodeMail(to, subject, body){
   // This smtp was set up by Brown OIT unix team -- this will only work on Brown internal network (such as BKE)
   // Auth not needed at this time
-  let EMAIL_SMTP = "smtp://mail-relay.brown.edu:25"
+  let EMAIL_SMTP = "smtp://regmail.brown.edu:25"
   let transporter
   // Initiate transporter
   if (EMAIL_SMTP !== undefined) {


### PR DESCRIPTION
Per Brad, UNIX will be disabling `mailrelay.brown.edu`, so we will switch over to using `regmail` smtp server